### PR TITLE
Handle documents with different structure.

### DIFF
--- a/MongoDbDataLoader/Program.cs
+++ b/MongoDbDataLoader/Program.cs
@@ -61,6 +61,11 @@ namespace MongoDbDataLoader
         {
             var list = new List<Person>(200);
 
+            var noType0 = new Person(1000000, 10, 10);
+            noType0.Addresses["type0"] = null;
+
+            list.Add(noType0);
+
             for (int i = 0; i < 200; i++)
             {
                 var person = new Person(i, 2, 3);

--- a/MongoDbSupplyCollector/MongoDbSupplyCollector.cs
+++ b/MongoDbSupplyCollector/MongoDbSupplyCollector.cs
@@ -70,8 +70,11 @@ namespace MongoDbSupplyCollector
 
             if (value.IsBsonDocument)
             {
-                value = value[currentProperty];
-                AddSamples(samples, value, subProperty);
+                if (value.ToBsonDocument().Contains(currentProperty))
+                {
+                    value = value[currentProperty];
+                    AddSamples(samples, value, subProperty);
+                }               
             }
             else
             {

--- a/MongoDbSupplyCollectorTests/MongoDbSupplyCollectorTests.cs
+++ b/MongoDbSupplyCollectorTests/MongoDbSupplyCollectorTests.cs
@@ -74,8 +74,8 @@ namespace MongoSupplyCollectorTests
         [Fact]
         public void CollectNestedStreetDataSampleTest()
         {
-            var samples = _instance.CollectSample(_type0Street1, 127);
-            Assert.Equal(127, samples.Count);
+            var samples = _instance.CollectSample(_type0Street1, 201);
+            Assert.Equal(200, samples.Count);
             Assert.Contains("Street10", samples);
         }
 

--- a/MongoDbSupplyCollectorTests/MongoDbSupplyCollectorTests.cs
+++ b/MongoDbSupplyCollectorTests/MongoDbSupplyCollectorTests.cs
@@ -55,8 +55,9 @@ namespace MongoSupplyCollectorTests
         public void GetSchemaTest()
         {
             var (tables, elements) = _instance.GetSchema(_container);
+
             Assert.Equal(4, tables.Count);
-            Assert.Equal(171, elements.Count);
+            Assert.Equal(212, elements.Count);
             foreach(DataEntity element in elements)
             {
                 Assert.NotEqual(string.Empty, element.DbDataType);
@@ -99,13 +100,13 @@ namespace MongoSupplyCollectorTests
             Assert.Equal(4, result.Count);
 
             Assert.Equal(200, contactsAuditMetrics.RowCount);
-            Assert.Equal(116, contactsAuditMetrics.TotalSpaceKB);
+            Assert.Equal(104, contactsAuditMetrics.TotalSpaceKB);
 
             Assert.Equal(200, leadsMetrics.RowCount);
-            Assert.Equal(112, leadsMetrics.TotalSpaceKB);
+            Assert.Equal(92, leadsMetrics.TotalSpaceKB);
 
             Assert.Equal(200, emailMetrics.RowCount);
-            Assert.Equal(84, emailMetrics.TotalSpaceKB);
+            Assert.Equal(72, emailMetrics.TotalSpaceKB);
 
         }
 


### PR DESCRIPTION
Every document in MongoDB might have a different structure. So CollectSchema might return data entities that not every document has. This PR reproduces this problem with some test data and has an actual fix for it.